### PR TITLE
feat(work): classify repos and fix sort order

### DIFF
--- a/data/overrides.yml
+++ b/data/overrides.yml
@@ -1,6 +1,8 @@
 # Hand-authored overrides keyed by repo name.
 # See docs/catalog.md for supported fields.
 
+# ─── Active Flexion-originated projects ───────────────────────────────────────
+
 forms:
   tier: active
   category: product
@@ -11,12 +13,175 @@ forms-lab:
   category: product
   featured: true
 
+flexion-notify:
+  tier: active
+  category: product
+  featured: true
+
+devops-deployment-metrics:
+  tier: active
+  category: tool
+  featured: true
+
+flexion.github.io:
+  tier: active
+  category: tool
+
+claude-domestique:
+  tier: active
+  category: tool
+
+aws-codebuild-runner-project-tf-module:
+  tier: active
+  category: tool
+
+odoo-ai-assistant:
+  tier: active
+  category: tool
+
+flexcoins:
+  tier: active
+  category: product
+
+# ─── Active forks (significant project contributions) ─────────────────────────
+
+ef-cms:
+  tier: active
+
+ef-cms-ustc:
+  tier: active
+
+notifications-admin:
+  tier: active
+
+notifications-api:
+  tier: active
+
 document-extractor:
   tier: active
   category: product
   featured: true
 
-flexion-notify:
+uswds:
   tier: active
+
+uswds-site:
+  tier: active
+
+uswds-elements:
+  tier: active
+
+# ─── Active prototypes (bid/design work) ──────────────────────────────────────
+
+Destin-Municipal-Prototype:
+  tier: active
+  category: prototype
+
+Destin-Design-Repo:
+  tier: active
+  category: prototype
+
+# ─── Categorized (unreviewed tier, but with a useful category) ────────────────
+
+bash_shell_script_starter:
+  category: tool
+
+flexion-sig-security:
+  category: tool
+
+flexion-sig-security-tf-modules:
+  category: tool
+
+msab-arts-locator:
   category: product
-  featured: true
+
+tech-radar-generator:
+  category: tool
+
+check-contributor-allowlist-action:
+  category: tool
+
+strapi-provider-upload-aws-s3-auth:
+  category: tool
+
+jubilant-computing-machine:
+  category: tool
+
+10x-uswds-forms:
+  category: prototype
+
+10x-uswds-dataviz:
+  category: prototype
+
+epa-prototype:
+  category: prototype
+
+flexion-ads-18f-response:
+  category: prototype
+
+flexion-ads-18f-save-my-picnic:
+  category: prototype
+
+qpp-design-exercise:
+  category: prototype
+
+Planet-Express:
+  category: tool
+
+asset-manager:
+  category: prototype
+
+# ─── Hidden (no portfolio value, visible only on Health page) ─────────────────
+
+# Dead forks (2012–2015, no stars, no meaningful contribution)
+node-js-crate:
+  hidden: true
+
+coffeescript-koans:
+  hidden: true
+
+javascript-koans:
+  hidden: true
+
+pallet:
+  hidden: true
+
+django-axes:
+  hidden: true
+
+django-ckeditor:
+  hidden: true
+
+custom-post-type-ui:
+  hidden: true
+
+django:
+  hidden: true
+
+docker-karma-protractor:
+  hidden: true
+
+hubot-google-hangouts:
+  hidden: true
+
+lookml:
+  hidden: true
+
+# Dead non-forks (no README, no license, no description, or clearly abandoned)
+pig-latin-cli:
+  hidden: true
+
+mini-project-1:
+  hidden: true
+
+cdk-playground:
+  hidden: true
+
+mob-timer:
+  hidden: true
+
+uswds-react:
+  hidden: true
+
+radar:
+  hidden: true

--- a/src/pages/work/health.tsx
+++ b/src/pages/work/health.tsx
@@ -37,15 +37,14 @@ export function Health({
   config: SiteConfig
   showPerRepo: boolean
 }) {
-  const visible = catalog.filter((e) => !e.hidden)
-  const evaluations = visible.map((e) => ({ entry: e, evaluation: evaluateRepo(e, now) }))
+  const evaluations = catalog.map((e) => ({ entry: e, evaluation: evaluateRepo(e, now) }))
   const passing = evaluations.filter(({ evaluation }) => evaluation.overallPass).length
 
   return (
     <Layout title="Repo health" config={config}>
       <h1>Repo health</h1>
       <p class="health-summary">
-        <strong>{passing}</strong> of <strong>{visible.length}</strong> repos meet the documented standards.
+        <strong>{passing}</strong> of <strong>{catalog.length}</strong> repos meet the documented standards.
       </p>
 
       {showPerRepo ? (

--- a/src/pages/work/index.tsx
+++ b/src/pages/work/index.tsx
@@ -2,6 +2,7 @@ import { Layout } from '../../design/common/layout'
 import { RepoCard } from '../../design/components/repo-card'
 import { Select } from '../../design/components/select'
 import type { Catalog, CatalogEntry } from '../../catalog/types'
+import { url } from '../../build/config'
 import type { SiteConfig } from '../../build/config'
 
 declare module 'hono/jsx' {
@@ -28,7 +29,9 @@ export function WorkIndex({
       <p class="work-index__intro">
         Flexion's public portfolio — tools we've built, prototypes we've shipped, and
         open-source projects we actively contribute to. Use the filters to explore by
-        tier or category.
+        tier or category. See our{' '}
+        <a href={url('/work/health/', config.basePath)}>stewardship scorecard</a> for
+        how each repo measures up.
       </p>
       <catalog-filter>
         <form class="catalog-filter">

--- a/src/pages/work/index.tsx
+++ b/src/pages/work/index.tsx
@@ -26,9 +26,9 @@ export function WorkIndex({
     <Layout title="Work" config={config}>
       <h1>Our work</h1>
       <p class="work-index__intro">
-        Every public repository Flexion maintains. Active projects are stewarded; as-is
-        projects are available without promised maintenance; archived projects are no
-        longer updated.
+        Flexion's public portfolio — tools we've built, prototypes we've shipped, and
+        open-source projects we actively contribute to. Use the filters to explore by
+        tier or category.
       </p>
       <catalog-filter>
         <form class="catalog-filter">
@@ -37,9 +37,9 @@ export function WorkIndex({
             <Select name="tier" label="Tier">
               <option value="">All</option>
               <option value="active">Active</option>
+              <option value="unreviewed">Unreviewed</option>
               <option value="as-is">As-is</option>
               <option value="archived">Archived</option>
-              <option value="unreviewed">Unreviewed</option>
             </Select>
             <Select name="category" label="Category">
               <option value="">All</option>
@@ -80,8 +80,8 @@ function defaultSort(a: CatalogEntry, b: CatalogEntry): number {
   if (a.featured !== b.featured) return a.featured ? -1 : 1
   const tierRank: Record<CatalogEntry['tier'], number> = {
     active: 0,
-    'as-is': 1,
-    unreviewed: 2,
+    unreviewed: 1,
+    'as-is': 2,
     archived: 3,
   }
   if (tierRank[a.tier] !== tierRank[b.tier]) return tierRank[a.tier] - tierRank[b.tier]

--- a/tests/views/health.test.tsx
+++ b/tests/views/health.test.tsx
@@ -13,11 +13,14 @@ describe('Health', () => {
     expect(html).toMatch(/of\s+<strong>\d+<\/strong>\s+repos meet the documented standards/)
   })
 
-  test('renders a table with one row per non-hidden repo', async () => {
-    const html = await renderToHtml(
-      <Health catalog={fixtureCatalog} now={fixtureNow} config={config} showPerRepo={true} />,
+  test('renders a table with one row per repo including hidden', async () => {
+    const catalog = fixtureCatalog.map((e, i) =>
+      i === 0 ? { ...e, hidden: true } : e,
     )
-    for (const entry of fixtureCatalog.filter((e) => !e.hidden)) {
+    const html = await renderToHtml(
+      <Health catalog={catalog} now={fixtureNow} config={config} showPerRepo={true} />,
+    )
+    for (const entry of catalog) {
       expect(html).toContain(`data-repo="${entry.name}"`)
     }
   })


### PR DESCRIPTION
## Summary

- **Fix sort order**: Flexion-originated repos now appear before forks (swapped `unreviewed` rank above `as-is`)
- **Populate `overrides.yml`**: Classify all 73 repos — 16 active, 16 categorized, 17 hidden, 2 featured
- **Health page shows all repos** (including hidden) for stewardship accountability

## Context

The Work page previously showed 42 forks before any Flexion-originated work because the tier sort ranked `as-is` (default for forks) above `unreviewed` (default for own repos). The `overrides.yml` was completely empty, making filters decorative.

Now the page shows 56 visible repos in a meaningful order: featured first, then active projects (including significant forks like ef-cms, Notify.gov, USWDS), then categorized older work, then remaining forks.

## Follow-up work

- [ ] Write overlays for featured/active repos (detail page content)
- [ ] Add READMEs/descriptions to repos missing them on GitHub
- [ ] Archive hidden repos on GitHub itself
- [ ] Consider section headings or grouped layout
- [ ] "Contribute-back" badge for promoted forks

## Test plan

- `bun test` — 49 tests pass (a11y suite excluded, requires build)
- `bun run build` — site builds cleanly
- Verified Work page shows 56 repos with active first, hidden repos excluded
- Verified Health page shows all 73 repos for accountability