### PR TITLE
ci(refresh-catalog): fetch branch before force-with-lease

### DIFF
--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -39,6 +39,8 @@ jobs:
           BRANCH="catalog/refresh-$DATE"
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
+          # Ensure remote-tracking ref exists so --force-with-lease works on retries.
+          git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || true
           git checkout -B "$BRANCH"
           git add data/repos.json
           git commit -m "chore(catalog): refresh snapshot $DATE"


### PR DESCRIPTION
## Summary
- Refresh-catalog workflow fails on re-run with `git push --force-with-lease` returning `(stale info)` because `actions/checkout@v4` only fetches `main` and there's no remote-tracking ref for the dated `catalog/refresh-*` branch.
- Adds an explicit fetch (best-effort) of the existing branch right before the push so the lease has a reference to compare against. First-time runs are unaffected (the `|| true` covers the missing-branch case).

## Repro
Today's scheduled run (`25209783851`, attempt 2) failed with:
```
! [rejected] catalog/refresh-2026-05-01 -> catalog/refresh-2026-05-01 (stale info)
```

## Test plan
- [x] Workflow YAML still parses
- [ ] After merge, trigger `workflow_dispatch` and confirm the job completes; PR #14 picks up auto-merge