### PR TITLE
Update Forms demo URLs to labs.flexion.us subdomains

### DIFF
--- a/content/featured/forms-lab.md
+++ b/content/featured/forms-lab.md
@@ -4,13 +4,13 @@ tagline: Digitize forms to create modern, accessible experiences for public outr
 order: 1
 links:
   - label: Forms Platform
-    url: https://pp4cc7kwbf.us-east-1.awsapprunner.com/
+    url: https://10x-forms.labs.flexion.us/
     kind: demo
   - label: flexion/forms
     url: https://github.com/flexion/forms
     kind: repo
   - label: Forms Lab (experiment)
-    url: https://ec2-34-197-222-16.compute-1.amazonaws.com/
+    url: https://forms.labs.flexion.us/
     kind: demo
   - label: flexion/forms-lab
     url: https://github.com/flexion/forms-lab

--- a/data/repos.json
+++ b/data/repos.json
@@ -543,7 +543,7 @@
     "name": "forms-lab",
     "description": "Experiments in delivering friendly government forms.",
     "url": "https://github.com/flexion/forms-lab",
-    "homepage": "https://ec2-34-197-222-16.compute-1.amazonaws.com",
+    "homepage": "https://forms.labs.flexion.us",
     "language": "TypeScript",
     "license": "Apache-2.0",
     "pushedAt": "2026-04-21T14:34:26Z",

--- a/tests/build/featured.test.ts
+++ b/tests/build/featured.test.ts
@@ -24,7 +24,7 @@ describe('loadFeatured', () => {
     expect(forms.links.map((l) => l.kind)).toEqual(['demo', 'repo', 'demo', 'repo'])
     expect(forms.links[0]).toEqual({
       label: 'Forms Platform',
-      url: 'https://pp4cc7kwbf.us-east-1.awsapprunner.com/',
+      url: 'https://10x-forms.labs.flexion.us/',
       kind: 'demo',
     })
   })

--- a/tests/views/home.test.tsx
+++ b/tests/views/home.test.tsx
@@ -21,7 +21,7 @@ const featured: FeaturedLab[] = [
     tagline: 'Digitize forms to create modern, accessible experiences for public outreach.',
     order: 1,
     links: [
-      { label: 'Forms Platform', url: 'https://pp4cc7kwbf.us-east-1.awsapprunner.com/', kind: 'demo' },
+      { label: 'Forms Platform', url: 'https://10x-forms.labs.flexion.us/', kind: 'demo' },
       { label: 'flexion/forms', url: 'https://github.com/flexion/forms', kind: 'repo' },
     ],
   },


### PR DESCRIPTION
## Summary
- Updates Forms Platform demo URL from AWS App Runner hostname to `10x-forms.labs.flexion.us`
- Updates Forms Lab demo URL from EC2 hostname to `forms.labs.flexion.us`
- Updates corresponding test fixtures and `data/repos.json` homepage

## Test plan
- [x] `bun test` passes (86 tests, 0 failures)
- [ ] Verify demo links work on the preview deploy