### PR TITLE
Fix catalog refresh: reuse PR, remove stars, enable auto-merge

### DIFF
--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -36,7 +36,7 @@ jobs:
             exit 0
           fi
           DATE="$(date -u +%F)"
-          BRANCH="catalog/refresh-$DATE"
+          BRANCH="catalog/refresh"
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           # Ensure remote-tracking ref exists so --force-with-lease works on retries.
@@ -47,7 +47,7 @@ jobs:
           git push --force-with-lease origin "$BRANCH"
           if ! gh pr view "$BRANCH" >/dev/null 2>&1; then
             gh pr create --base main --head "$BRANCH" \
-              --title "Refresh catalog snapshot — $DATE" \
+              --title "Refresh catalog snapshot" \
               --body "Automated snapshot refresh from the GitHub API."
           fi
           gh pr merge "$BRANCH" --auto --squash

--- a/src/catalog/refresh.ts
+++ b/src/catalog/refresh.ts
@@ -48,7 +48,6 @@ export async function buildSnapshot(
       pushedAt: repo.pushed_at,
       archived: repo.archived,
       fork: repo.fork,
-      stars: repo.stargazers_count,
       hasReadme,
       hasLicense: Boolean(repo.license?.spdx_id) || hasLicenseFile,
       hasContributing,

--- a/src/catalog/types.ts
+++ b/src/catalog/types.ts
@@ -18,7 +18,6 @@ export type GithubSnapshotEntry = {
   pushedAt: string // ISO 8601
   archived: boolean
   fork: boolean
-  stars: number
   hasReadme: boolean
   hasLicense: boolean
   hasContributing: boolean

--- a/src/design/components/repo-card/examples.tsx
+++ b/src/design/components/repo-card/examples.tsx
@@ -11,7 +11,6 @@ const example: CatalogEntry = {
   pushedAt: '2026-04-20T00:00:00Z',
   archived: false,
   fork: false,
-  stars: 12,
   hasReadme: true,
   hasLicense: true,
   hasContributing: true,

--- a/tests/catalog/refresh.test.ts
+++ b/tests/catalog/refresh.test.ts
@@ -11,7 +11,6 @@ const apiRepo = (overrides: Record<string, unknown>) => ({
   pushed_at: '2026-01-01T00:00:00Z',
   archived: false,
   fork: false,
-  stargazers_count: 0,
   private: false,
   ...overrides,
 })
@@ -34,7 +33,6 @@ describe('buildSnapshot', () => {
         homepage: 'https://messaging.example/',
         language: 'TypeScript',
         license: { spdx_id: 'Apache-2.0' },
-        stargazers_count: 3,
         pushed_at: '2026-04-20T00:00:00Z',
       }),
     ]), {
@@ -46,7 +44,7 @@ describe('buildSnapshot', () => {
     const snapshot = await buildSnapshot({ org: 'flexion', fetch: fetchImpl, fileCheck })
     expect(snapshot[0].name).toBe('messaging')
     expect(snapshot[0].license).toBe('Apache-2.0')
-    expect(snapshot[0].stars).toBe(3)
+    expect('stars' in snapshot[0]).toBe(false)
     expect(snapshot[0].hasReadme).toBe(true)
     expect(snapshot[0].hasContributing).toBe(false)
   })


### PR DESCRIPTION
## Summary

- Remove unused `stars` field from catalog snapshot to reduce spurious diffs (star counts change frequently but were never rendered)
- Use stable branch name `catalog/refresh` instead of `catalog/refresh-$DATE` so repeated runs update the same PR instead of creating new ones
- Enabled branch protection on `main` requiring `build-and-test` status check so `gh pr merge --auto` actually works (was silently failing with no protection configured)
- Closed 4 stale date-stamped PRs (#17, #18, #20, #21) that accumulated due to the above issues

## Test plan
- [x] All 86 tests pass
- [x] Branch protection verified via `gh api`
- [ ] After merge, trigger manual workflow run (`gh workflow run "Refresh catalog"`) to regenerate `data/repos.json` without `stars` and confirm auto-merge completes