### PR TITLE
Home h1 tweak

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -1,6 +1,6 @@
 ---
-title: Flexion Labs
-subtitle: Solutions for the public, in the open
+title: Solutions for the public, in the open
+subtitle:
 intro: |
   Flexion is committed to excellence in civic technology. We are also
   committed to transparency. As part of that commitment, Flexion Labs


### PR DESCRIPTION
Avoid duplication in the "Flexion Labs" title by replacing it with the "Solutions for the public, in the open" subtitle.