### PR TITLE
Fix broken links on design system page

### DIFF
--- a/src/design/components/catalog-filter/examples.tsx
+++ b/src/design/components/catalog-filter/examples.tsx
@@ -3,7 +3,7 @@ export function CatalogFilterExamples() {
     <section id="catalog-filter">
       <h2>Catalog filter</h2>
       <p>An HTML Web Component (<code>&lt;catalog-filter&gt;</code>) that wraps a filter form and list. With JavaScript, filters items in-place by tier and category. Without JavaScript, the form submits as a GET request.</p>
-      <p><em>See the <a href="work/">Work</a> page for a live example.</em></p>
+      <p><em>Live example coming soon — the Work page is not yet published.</em></p>
     </section>
   )
 }

--- a/src/design/components/link/examples.tsx
+++ b/src/design/components/link/examples.tsx
@@ -7,7 +7,7 @@ export function LinkExamples() {
       <p>Navigational anchors. External links automatically add <code>rel="noopener external"</code> and a visual icon indicator.</p>
 
       <h3>Internal link</h3>
-      <p><Link href="work/">View our work</Link></p>
+      <p><Link href="/commitment/">Our commitment</Link></p>
 
       <h3>External link</h3>
       <p><Link href="https://github.com/flexion" external>Flexion on GitHub</Link></p>

--- a/src/design/components/sortable-table/examples.tsx
+++ b/src/design/components/sortable-table/examples.tsx
@@ -3,7 +3,7 @@ export function SortableTableExamples() {
     <section id="sortable-table">
       <h2>Sortable table</h2>
       <p>An HTML Web Component (<code>&lt;sortable-table&gt;</code>) that wraps a table. Column headers become clickable sort controls. Works without JavaScript — the default sort is applied server-side.</p>
-      <p><em>See the <a href="work/health/">Health</a> page for a live example.</em></p>
+      <p><em>Live example coming soon — the Health page is not yet published.</em></p>
     </section>
   )
 }


### PR DESCRIPTION
## Summary

- The "Work" and "Health" links on `/design-system/` return 404 because those routes are currently disabled
- Replaced dead links in the sortable-table and catalog-filter component examples with placeholder text noting the pages aren't yet published
- Updated the Link component example to point to `/commitment/`, which is a live route

## Test plan

- [ ] Visit `/design-system/` and confirm no links 404
- [ ] Verify the Link component example navigates to `/commitment/` correctly